### PR TITLE
Remove sudo and package dependencies from travis file (so we can have…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: node_js
 node_js:
   - "0.10"


### PR DESCRIPTION
… travis containers)

Our unit tests here shouldn't require sudo or apt updates, so remove them in order to support new travis containerized infrastructure.

@heckj 