### PR TITLE
Adds node v4 to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: node_js
+
 node_js:
   - "0.10"
+  - "4"
+
+matrix:
+  allow_failures:
+   - node_js: "4"
+
 after_success:
  - ./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha --report lcovonly -- $(find spec -name '*-spec.js') -R spec --require spec/helper.js
  - cat ./coverage/lcov.info | node_modules/.bin/coveralls


### PR DESCRIPTION
This adds node version for to travis build matrix so that failures are allowed. Same as `on-core`.