### PR TITLE
rationalizing logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var di = require('di'),
 
 tftp.start()
 .catch(function(err) {
-    logger.error('Failure starting TFTP service' + err.stack);
+    logger.critical('Failure starting TFTP service' + err.stack);
     process.nextTick(function(){
         process.exit(1);
     });
@@ -26,7 +26,7 @@ tftp.start()
 process.on('SIGINT',function() {
     tftp.stop()
     .catch(function(err) {
-        logger.error('Failure cleaning up TFTP service' + err.stack);
+        logger.critical('Failure cleaning up TFTP service' + err.stack);
     })
     .finally(function() {
         process.nextTick(function(){
@@ -34,4 +34,3 @@ process.on('SIGINT',function() {
         });
     });
 });
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,7 +33,7 @@ function TftpServerFactory(Logger, configuration, eventsProtocol, lookupService)
     });
 
     tftp.on("error", function(err) {
-      logger.emerg("TFTP main socket error: ", err);
+      logger.critical("TFTP main socket error: ", err);
       setImmediate(function() {
           process.exit(-1); // exit the program entirely if we can't listen for TFTP requests
       });
@@ -59,7 +59,7 @@ function TftpServerFactory(Logger, configuration, eventsProtocol, lookupService)
             var diff = process.hrtime(req._startAt);
             var ms = diff[0] * 1e3 + diff[1] * 1e-6;
 
-            logger.silly('tftp: ' + ms.toFixed(3) + ' ' + req.file, {
+            logger.debug('tftp: ' + ms.toFixed(3) + ' ' + req.file, {
                 ip: req.stats.remoteAddress
             });
 
@@ -105,4 +105,3 @@ function TftpServerFactory(Logger, configuration, eventsProtocol, lookupService)
 
     return tftp;
 }
-


### PR DESCRIPTION
updating mapping to more constricted set of logs per
https://github.com/RackHD/RackHD/issues/34

**NOTE**: Requires https://github.com/RackHD/on-core/pull/48 to be
committed prior as it adds the synonym 'critical' to the existing 'crit'
level.