### PR TITLE
Remove entrypoint from Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.bintray.json
+.dockerignore
+.git
+.gitignore
+.hound.yml
+.jshintrc
+.travis.yml
+debian/
+Dockerfile
+Gruntfile.js
+HWIMO-*
+LICENSE
+migrate.js
+README.md
+spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,4 @@ ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/undionly.kpxe \
 EXPOSE 69
 EXPOSE 69/udp
 
-ENTRYPOINT [ "node" ]
-CMD [ "/RackHD/on-tftp/index.js" ]
+CMD [ "node", "/RackHD/on-tftp/index.js" ]


### PR DESCRIPTION
This makes it easier to debug docker images and containers.