### PR TITLE
Handle serving file templates in addition to static files. Add cisco-…

### DIFF
--- a/data/templates/cisco-poap.py
+++ b/data/templates/cisco-poap.py
@@ -1,0 +1,27 @@
+# Copyright 2016, EMC, Inc.
+
+import urllib2
+import json
+import imp
+import traceback
+import sys
+
+def download_cisco_script():
+    # Add switch vendor string as the last URI element as a hint to the
+    # HTTP API server
+    script = urllib2.urlopen('<%=switchProfileUri%>/cisco').read()
+    with open('rackhd_cisco_script.py', 'w') as rackhd_cisco_script:
+        rackhd_cisco_script.write(script)
+
+try:
+    download_cisco_script()
+    execfile('./rackhd_cisco_script.py')
+except SystemExit as e:
+    sys.exit(e)
+except:
+    data = json.dumps({"error": traceback.format_exc()})
+    req = urllib2.Request('<%=switchProfileErrorUri%>', data, {"Content-Type": "application/json"})
+    urllib2.urlopen(req)
+    # Don't swallow exceptions otherwise the Cisco switch will think the POAP was a success
+    # and proceed to boot rather than retrying
+    raise error

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,39 +11,76 @@ di.annotate(TftpServerFactory, new di.Inject(
         'Logger',
         'Services.Configuration',
         'Protocol.Events',
-        'Services.Lookup'
+        'Services.Lookup',
+        'FileLoader',
+        'Constants',
+        'ejs'
     )
 );
 
-
-function TftpServerFactory(Logger, configuration, eventsProtocol, lookupService) {
+function TftpServerFactory(
+    Logger,
+    configuration,
+    eventsProtocol,
+    lookupService,
+    FileLoader,
+    Constants,
+    ejs
+) {
     var logger = Logger.initialize(TftpServerFactory);
 
     function Tftp() {
         this.host = configuration.get('tftpBindAddress', '0.0.0.0');
         this.port = configuration.get('tftpBindPort', 69);
         this.root = configuration.get('tftpRoot', './static/tftp');
+        var switchProfileUri = 'http://%s:%s/api/1.1/profiles/switch'.format(
+            configuration.get('apiServerAddress', '10.1.1.1'),
+            configuration.get('apiServerPort', '9080')
+        );
+        var switchProfileErrorUri = switchProfileUri + '/error/';
+        this.renderContext = {
+            switchProfileUri: switchProfileUri,
+            switchProfileErrorUri: switchProfileErrorUri
+        };
+        this.templates = {};
 
-        this._tftp = tftpd.createServer({
-            host: this.host,
-            port: this.port,
-            root: this.root
-        });
+        this._tftp = tftpd.createServer(
+            {
+                host: this.host,
+                port: this.port,
+                root: this.root
+            },
+            this.requestWrapper.bind(this)
+        );
     }
 
     Tftp.prototype.logListening  = function() {
-        logger.info("TFTP Server Listening %s:%s".format(Tftp.host, Tftp.port));
+        logger.info("TFTP Server Listening %s:%s".format(this.host, this.port));
     };
 
     Tftp.prototype.handleError = function(err) {
-      logger.critical("TFTP main socket error: ", err);
-      setImmediate(function() {
-          process.exit(-1); // exit the program entirely if we can't listen for TFTP requests
-      });
+        logger.critical("TFTP main socket error: ", err);
+        setImmediate(function() {
+            process.exit(-1); // exit the program entirely if we can't listen for TFTP requests
+        });
     };
 
     Tftp.prototype.logClose = function() {
         logger.info("TFTP server closed.");
+    };
+
+    Tftp.prototype.requestWrapper = function(req, res) {
+        if (this.templates[req.file]) {
+            logger.info('Serving custom template', {
+                template: req.file,
+                remoteAddress: req.stats.remoteAddress,
+            });
+            var script = ejs.render(this.templates[req.file].toString(), this.renderContext);
+            res.setSize(script.length);
+            res.end(script);
+        } else {
+            this._tftp.requestListener(req, res);
+        }
     };
 
     Tftp.prototype.handleRequest = function(req, res){
@@ -112,7 +149,13 @@ function TftpServerFactory(Logger, configuration, eventsProtocol, lookupService)
     };
 
     Tftp.prototype.start = function() {
-        this.listen();
+        var self = this;
+        var loader = new FileLoader();
+        return loader.getAll(Constants.Templates.Directory)
+        .then(function(templates) {
+            self.templates = templates;
+            self.listen();
+        });
     };
 
     Tftp.prototype.stop = function(){


### PR DESCRIPTION
…poap.py template.

Update the TFTP server to support serving file templates rendered in memory in addition to just static files. This update is required to support Cisco POAP auto-installation, which only supports TFTP downloads as an initial mechanism.

Also add a cisco-poap.py template to kickstart the bootstrap process to start talking with our API server in order to use the more dynamic discovery mechanisms we implement with the rest of the RackHD projects.

Supports:
https://github.com/RackHD/on-http/pull/210
https://github.com/RackHD/on-tasks/pull/158
https://github.com/RackHD/on-taskgraph/pull/84
https://github.com/RackHD/on-dhcp-proxy/pull/32

@RackHD/corecommitters @zyoung51 @heckj @VulpesArtificem @johren @pscharla 