### PR TITLE
Fix for debian/ova deployments.

### DIFF
--- a/debian/on-tftp.install
+++ b/debian/on-tftp.install
@@ -1,5 +1,6 @@
 node_modules /var/renasar/on-tftp
 lib /var/renasar/on-tftp
 static /var/renasar/on-tftp
+data /var/renasar/on-tftp
 index.js /var/renasar/on-tftp
 commitstring.txt /var/renasar/on-tftp


### PR DESCRIPTION
The new code from #60 references /var/renasar/on-tftp/data/templates.
The structure was set up for this, but got left out of the
debian on-tftp.install file. So, when deployed using deb-packages,
on-tftp would abort, making discovery a weeee bit difficult.

#This is block hardware smoke tests

@RackHD/corecommitters .... Direct target of @benbp since #60 got *almost* everything, except this line :)
