### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,6 @@ Dockerfile
 Gruntfile.js
 HWIMO-*
 LICENSE
-migrate.js
+node_modules/
 README.md
 spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,14 @@
 
 FROM rackhd/on-core
 
-RUN mkdir -p /RackHD/on-tftp
+COPY . /RackHD/on-tftp/
 WORKDIR /RackHD/on-tftp
 
-COPY ./package.json /tmp/
-RUN cd /tmp \
-  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
+RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-core ./node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production
 
-COPY . /RackHD/on-tftp/
-RUN cp -a -f /tmp/node_modules /RackHD/on-tftp/
-
 EXPOSE 69/udp
-
 VOLUME /RackHD/on-tftp/static/tftp
-
 CMD [ "node", "/RackHD/on-tftp/index.js" ]


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.