### PR TITLE
Get 'contents' key from template objects

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -75,7 +75,7 @@ function TftpServerFactory(
                 template: req.file,
                 remoteAddress: req.stats.remoteAddress,
             });
-            var script = ejs.render(this.templates[req.file].toString(), this.renderContext);
+            var script = ejs.render(this.templates[req.file].contents.toString(), this.renderContext);
             res.setSize(script.length);
             res.end(script);
         } else {

--- a/spec/lib/server-spec.js
+++ b/spec/lib/server-spec.js
@@ -104,7 +104,10 @@ describe('tftp server tests', function () {
                 end: sinon.stub()
             };
             server.templates = {
-                test: '<%=switchProfileUri%> <%=switchProfileErrorUri%>'
+                test: {
+                    contents: '<%=switchProfileUri%> <%=switchProfileErrorUri%>',
+                    path: 'testpath'
+                }
             };
 
             server.requestWrapper(req, res);


### PR DESCRIPTION
The core change to the template storage model broke this functionality: https://github.com/RackHD/on-core/commit/b990180345f28e464a60449edd37b6843451ec27

@RackHD/corecommitters @larry-dean @johren 