### PR TITLE
Decouple tftp server and switch template

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -33,14 +33,12 @@ function TftpServerFactory(
         this.host = configuration.get('tftpBindAddress', '0.0.0.0');
         this.port = configuration.get('tftpBindPort', 69);
         this.root = configuration.get('tftpRoot', './static/tftp');
-        var switchProfileUri = 'http://%s:%s/api/1.1/profiles/switch'.format(
-            configuration.get('apiServerAddress', '10.1.1.1'),
-            configuration.get('apiServerPort', '9080')
-        );
-        var switchProfileErrorUri = switchProfileUri + '/error/';
+        var apiServerAddress = configuration.get('apiServerAddress', '10.1.1.1');
+        var apiServerPort = configuration.get('apiServerPort', '9080');
+
         this.renderContext = {
-            switchProfileUri: switchProfileUri,
-            switchProfileErrorUri: switchProfileErrorUri
+            apiServerAddress: apiServerAddress,
+            apiServerPort: apiServerPort
         };
         this.templates = {};
 

--- a/spec/lib/server-spec.js
+++ b/spec/lib/server-spec.js
@@ -105,7 +105,7 @@ describe('tftp server tests', function () {
             };
             server.templates = {
                 test: {
-                    contents: '<%=switchProfileUri%> <%=switchProfileErrorUri%>',
+                    contents: '<%=apiServerAddress%> <%=apiServerPort%>',
                     path: 'testpath'
                 }
             };
@@ -118,9 +118,9 @@ describe('tftp server tests', function () {
             var rendered = res.end.firstCall.args[0];
             var size = res.setSize.firstCall.args[0];
 
-            var expected = server.renderContext.switchProfileUri +
+            var expected = server.renderContext.apiServerAddress +
                             ' ' +
-                            server.renderContext.switchProfileErrorUri;
+                            server.renderContext.apiServerPort;
             expect(rendered).to.equal(expected);
             expect(size).to.equal(expected.length);
         });


### PR DESCRIPTION
need to rebase after https://github.com/RackHD/on-tftp/pull/49  merged

1.  decouple switch template rendor codes with tftp server.js. only render common api server ip address and port.
2.  the effect is when users use non on-tftp TFTP server. user only need to change the configuration 'API_SERVER_ADDRESS' and  'API_SERVER_PORT' in cisco-poap.py

@RackHD/corecommitters @larry-dean 