### PR TITLE
support release: build debian package with version like: 1.2.3-20111012UTC-b2f2da(nigthly release) or 1.2.3(official release)

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -31,7 +31,7 @@ export DEBFULLNAME="The HWIMO Robots"
 # compute it as below:
 if [ -z "$PKG_VERSION" ];then
     GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
-    DATE_STRING=$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%SZ")
+    DATE_STRING=$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%dUTC")
 
     GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
 
@@ -40,7 +40,7 @@ if [ -z "$PKG_VERSION" ];then
     PKG_VERSION="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
 fi
 
-if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
+if [[ $PKG_VERSION =~ ^([0-9]+\.){2}[0-9]+$ ]];then
     # If version looks like 1.2.3, the build is official build.
     # So update the distribution of changelog from "UNRELEASED" to "unstable"
     dch -r ""

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -9,6 +9,12 @@
 set -e
 set -x
 
+# $1 should be a file which contains the release version.
+# For example:  PKG_VERSION=1.2.3-rc-abc...
+if [ -f "$1" ];then
+    source $1
+fi
+
 rm -rf packagebuild
 git clone . packagebuild
 pushd packagebuild
@@ -19,18 +25,17 @@ npm install --cache=`pwd`
 npm prune --production
 git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
 
-GITCOMMITDATE=$(git show -s --pretty="format:%ci")
-DATESTRING=$(date -d "$GITCOMMITDATE" -u +"%Y-%m-%d-%H%M%SZ")
-
-PKG_VERSION="$DATESTRING"
-if [ -n "$BUILD_NUMBER" ]
-then
-  PKG_VERSION="${PKG_VERSION}-${BUILD_NUMBER}"
-fi
-
 export DEBEMAIL="hwimo robots <hwimo@hwimo.lab.emc.com>"
 export DEBFULLNAME="The HWIMO Robots"
 
-dch -v ${PKG_VERSION} autobuild
+if [ ! -z "$PKG_VERSION" ];then
+    if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
+        dch -r ""
+    else
+        COMMIT_STR=`git log -n 1 --oneline`
+        dch -v $PKG_VERSION -u low $COMMIT_STR -b -m
+    fi
+fi
+
 debuild --no-lintian --no-tgz-check -us -uc
 popd

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -6,14 +6,13 @@
 # apt-get install git pbuilder dh-make ubuntu-dev-tools devscripts
 # apt-get install nodejs nodejs-legacy npm
 
+# Input (environment variables):
+# * PKG_VERSION: The version of debian package, 
+#                such as: 1.3.1 (official release);
+#
+
 set -e
 set -x
-
-# $1 should be a file which contains the release version.
-# For example:  PKG_VERSION=1.2.3-rc-abc...
-if [ -f "$1" ];then
-    source $1
-fi
 
 rm -rf packagebuild
 git clone . packagebuild
@@ -28,13 +27,26 @@ git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
 export DEBEMAIL="hwimo robots <hwimo@hwimo.lab.emc.com>"
 export DEBFULLNAME="The HWIMO Robots"
 
-if [ ! -z "$PKG_VERSION" ];then
-    if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
-        dch -r ""
-    else
-        COMMIT_STR=`git log -n 1 --oneline`
-        dch -v $PKG_VERSION -u low $COMMIT_STR -b -m
-    fi
+# If PKG_VERSION is not set as an environment variable
+# compute it as below:
+if [ -z "$PKG_VERSION" ];then
+    GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
+    DATE_STRING=$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%SZ")
+
+    GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
+
+    CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+
+    PKG_VERSION="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
+fi
+
+if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
+    # If version looks like 1.2.3, the build is official build.
+    # So update the distribution of changelog from "UNRELEASED" to "unstable"
+    dch -r ""
+else
+    COMMIT_STR=`git log -n 1 --oneline`
+    dch -v $PKG_VERSION -u low $COMMIT_STR -b -m
 fi
 
 debuild --no-lintian --no-tgz-check -us -uc


### PR DESCRIPTION
Build debian package with version naming:
 1. for nightly build: on-tftp will use version  1.2.3-commit date-commit hash, such as: 
     1.2.3-20111012UTC-b2f2da
2. for release build: on-tftp will use version 1.2.3 which comes from environment variable.