### PR TITLE
RAC6243: Fix node8 unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sinon": "^1.12.2",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",
-    "supertest": "^0.15.0",
+    "supertest": "^1.2.0",
     "xunit-file": "0.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "on-tftp",
   "version": "2.27.0",
   "description": "OnRack Tftp Server",
+  "//": "Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
   "main": "index.js",
   "scripts": {
     "doc": "jsdoc lib -r -d docs",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "name": "on-tftp",
   "version": "2.29.0",
   "description": "OnRack Tftp Server",
-  "//": "Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
   "main": "index.js",
   "scripts": {
     "doc": "jsdoc lib -r -d docs",


### PR DESCRIPTION
**Background**
----
Currently, unit test will fail in Nodejs 6 and Nodejs 8.
[https://rackhd.atlassian.net/browse/RAC-6232](https://rackhd.atlassian.net/browse/RAC-6232)

**AC**:
- Paired with @mcgg 
- Fix nodejs6 and nodejs8 unit test failures in local machine
- Don’t break nodejs 4 unit test
- Pilot run in travisci environment(don’t commit the fix, because further FIT test should pass before submitting


**Detail**
----
*case 1*
Failed to run ```npm test``` if use ```npm link``` to install modules.

- Cause:
supertest@0.15.0 doesn't support.end()

- Fix:
Upgrade supertest from 0.15.0 to 1.2.0

@anhou @iceiilin @mcgG @pengz1 