### PR TITLE
[RAC-6701] Fix NPM5 build dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ COPY . /RackHD/on-tftp/
 WORKDIR /RackHD/on-tftp
 
 RUN mkdir -p ./node_modules \
+  && npm install --ignore-scripts --production \
+  && rm -r ./node_modules/on-core ./node_modules/di \
   && ln -s /RackHD/on-core ./node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
-  && npm install --ignore-scripts --production
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di
 
 EXPOSE 69/udp
 VOLUME /RackHD/on-tftp/static/tftp


### PR DESCRIPTION
**Background**
https://rackhd.atlassian.net/browse/RAC-6701
This story is aimed to update node dependency to the version of 8.x in pipelines.
However, NPM 5.x (lower than 5.7.1) within node 8.x environment has an issue while building dependencies for docker image, that is it would remove dependencies built from web URL (git repo in our case).
Besides, fix the issue that, in node 6.x base image, linked on-core/di package from base image, then failed to build dependencies defined in package.json.

**Details**
As a workaround, build dependencies firstly, then link on-core/on-tasks/di from base image.

**Reviewers**
@iceiilin @PengTian0 @nortonluo @lanchongyizu